### PR TITLE
Wrap call to destroy in a try/catch

### DIFF
--- a/js/VimeoView.js
+++ b/js/VimeoView.js
@@ -93,7 +93,9 @@ define([
      */
     remove: function() {
       if (this.model._pauseWhenOffScreen) this.$el.off('inview.pauseWhenOffScreen');
-      this.player.destroy();
+
+      if (this.player._originalElement) this.player.destroy();
+
       Backbone.View.prototype.remove.call(this);
     }
 

--- a/js/VimeoView.js
+++ b/js/VimeoView.js
@@ -94,7 +94,11 @@ define([
     remove: function() {
       if (this.model._pauseWhenOffScreen) this.$el.off('inview.pauseWhenOffScreen');
 
-      if (this.player._originalElement) this.player.destroy();
+      try {
+        this.player.destroy();
+      } catch(e) {
+        console.log(e)
+      }
 
       Backbone.View.prototype.remove.call(this);
     }


### PR DESCRIPTION
Perform a check for _originalElement attribute before calling destroy on the player

fixes #9 and [FW-2996](https://github.com/adaptlearning/adapt_framework/issues/2996)